### PR TITLE
PIXI-112: Fix display of hotel scan records with more than 2 subjects.

### DIFF
--- a/src/main/resources/META-INF/resources/templates/screens/pixi_hotelScanRecord/pixi_hotelScanRecord_details.vm
+++ b/src/main/resources/META-INF/resources/templates/screens/pixi_hotelScanRecord/pixi_hotelScanRecord_details.vm
@@ -124,7 +124,7 @@
 
 #set($hotelSubjects = $!item.getChildItems("hotel_subjects/subject").size())
 
-<div class="report-section column-container col-${hotelSubjects}">
+<div class="report-section column-container col-2">
 ###foreach($i in [0..3])
 ##    #set($positionName = $hotel.positions_position.get($i).name)
 


### PR DESCRIPTION
Sets max of 2 subject columns before starting a new row.