### PR TITLE
Making biod upload only available to owner level permissions.

### DIFF
--- a/src/main/resources/META-INF/resources/scripts/xnat/plugin/pixi/pixi-projects.js
+++ b/src/main/resources/META-INF/resources/scripts/xnat/plugin/pixi/pixi-projects.js
@@ -10,6 +10,7 @@ var XNAT = getObject(XNAT || {});
 XNAT.plugin = getObject(XNAT.plugin || {});
 XNAT.plugin.pixi = getObject(XNAT.plugin.pixi || {});
 XNAT.plugin.pixi.projects = getObject(XNAT.plugin.pixi.projects || {});
+XNAT.plugin.pixi.getOnlyOwners = getObject(XNAT.plugin.pixi.getOnlyOwners || {});
 
 (function(factory) {
     if (typeof define === 'function' && define.amd) {
@@ -32,6 +33,24 @@ XNAT.plugin.pixi.projects = getObject(XNAT.plugin.pixi.projects || {});
                                                           'owner=true',
                                                           'member=true',
                                                           'collaborator=true']);
+
+        const response = await fetch(projectUrl, {
+            method: 'GET',
+            headers: {'Content-Type': 'application/json'}
+        })
+
+        return response.json()
+    }
+
+    XNAT.plugin.pixi.projects.getOnlyOwners = async function() {
+        console.debug(`pixi-projects.js: XNAT.plugin.pixi.projects.getOnlyOwners`);
+
+        let projectUrl = XNAT.url.restUrl('/data/projects');
+        projectUrl = XNAT.url.addQueryString(projectUrl, ['prearc_code=true',
+                                                          'recent=true',
+                                                          'owner=true',
+                                                          'member=false',
+                                                          'collaborator=false']);
 
         const response = await fetch(projectUrl, {
             method: 'GET',

--- a/src/main/resources/META-INF/resources/templates/screens/UploadBiodistribution.vm
+++ b/src/main/resources/META-INF/resources/templates/screens/UploadBiodistribution.vm
@@ -5,9 +5,11 @@
     <div class="form-instructions">
         <p>Upload a CSV file containing biodistribution data for small animal imaging studies.</p>
 
-        <p>Download a template CSV file <a href="$content.getURI('biod/BiodistributionTemplate.csv')" download>here</a>.</p>
+        <p>Download a template CSV file <a href="$content.getURI('biod/BiodistributionTemplate.csv')" download>here</a>.
+        Please use the template to find the correct column names for the data in your CSV.</p>
 
-        <p>Pleas use the template to find the correct column names for the data in your CSV.</p>
+        <p> Currently, biodistribution upload via CSV file is only available to owners of a project. The list of project below
+        corresponds to that level of file access.</p>
     </div>
 
     <form id="upload-form" name="upload-form" method="post">

--- a/src/main/resources/META-INF/resources/templates/screens/UploadBiodistribution.vm
+++ b/src/main/resources/META-INF/resources/templates/screens/UploadBiodistribution.vm
@@ -165,12 +165,30 @@
         selectBox.options.length = 0;
 
         projects.forEach(project => {
+            let keys = Object.keys(project)
+            const permissions_key = keys.filter((key) => key.startsWith("user_role"));
+            if (project[permissions_key] != "Owners") {
+                return;
+            }
             selectBox.options[selectBox.length] = new Option(project['id'], project['id'])
         })
+        if (selectBox.options.length === 0) {
+            XNAT.ui.dialog.open({
+                title: 'No Projects Available For Upload',
+                content: `<div class="info">Biodistribution upload is currently limited to project owners. As you are not an owner of any project you are not able to upload biodistribution data.</div>`,
+                buttons: [
+                    {
+                        label: 'OK',
+                        isDefault: true,
+                        close: true,
+                    }
+                ]
+            })
+        }
     }
 
     // Load projects and mappings then render select boxes
-    XNAT.plugin.pixi.projects.getAll()
+    XNAT.plugin.pixi.projects.getOnlyOwners()
             .then(resultSet => resultSet['ResultSet']['Result'])
             .then(projects => renderProjectSelectBox(projectEl, projects));
 


### PR DESCRIPTION
During REST testing we found that only those with owner permissions can create a project resource. As such, we have changed the front end to ensure that users are not shown any projects to which they should not be able to upload data. We're also checking this earlier in the backend for better error handling.